### PR TITLE
Set year and week number as the default suffix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,7 +29,7 @@ inputs:
   date_suffix:
     description: Date format to append as suffix to the tag
     required: false
-    default: ""
+    default: "%Y%V"
 
 runs:
   using: "composite"


### PR DESCRIPTION
<!--
Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.

This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
-->

### Description

Please explain the changes you made here and their impact.

### Checklist

- [ ] I have checked the code and ensure it adheres to the project's coding standards.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added any necessary documentation (if appropriate).
