### PR TITLE
Use git tag to fetch latest upstream version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # sync-upstream-release-tag
+
 Action to automatically create tag in a forked repo for the latest upstream release
 
 # Usage
-Add this to a `.github/workflows/sync.yaml` file in your fork
+
+1. Add a secret called `WORKFLOW_TOKEN` with write access to your repository
+2. Add this to a `.github/workflows/sync.yaml` file in your fork
+
 ```yaml
 name: Sync upstream
 # This runs every day on 1000 UTC
@@ -21,8 +25,10 @@ jobs:
     - name: Create upstream version tag
       uses: DataDog/sync-upstream-release-tag@v0.1.0
         with:
-	  github_actor: "${GITHUB_ACTOR}"
-	  github_repository: "${GITHUB_REPOSITORY}"
-	  github_token: ${{ secrets.GITHUB_TOKEN }}
+   github_actor: "${GITHUB_ACTOR}"
+   github_repository: "${GITHUB_REPOSITORY}"
+    # The token need to have write-all access on the repo for the rebase
+    # so we cannot use the action's default token
+   github_token: ${{ secrets.WORKFLOW_TOKEN }}
           upstream_repo: kubernetes-sigs/gcp-compute-persistent-disk-csi-driver
 ```

--- a/action.yml
+++ b/action.yml
@@ -62,7 +62,8 @@ runs:
       shell: bash
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
-      run:  echo tag=$(gh release list -R ${{ inputs.upstream_repo }} --exclude-drafts --exclude-pre-releases -L 10 | grep -Eo "\bv[0-9]+\.[0-9]+\.[0-9]+\b\s" | sort -V | tail -n1) >> $GITHUB_OUTPUT
+      # We consider that the tags following the semver format exactly are the tags from upstream
+      run: echo tag=$(git tag -l v\* | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -n1) >> $GITHUB_OUTPUT
     - name: Get dd tag
       id: get_dd_tag
       shell: bash


### PR DESCRIPTION
<!--
Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.

This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
-->

### Description

Using git tag will avoid an issue where we wouldn't get the latest tag if it had no corresponding release on upstream's Github.

### Checklist

- [ ] I have checked the code and ensure it adheres to the project's coding standards.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added any necessary documentation (if appropriate).
