### PR TITLE
[CMPT-2396] Add major version input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: Date format to append as suffix to the tag
     required: false
     default: "%Y%V"
+  major_version:
+    description: Major version regex
+    required: false
+    default: "[0-9]+"
 
 runs:
   using: "composite"
@@ -63,7 +67,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       # We consider that the tags following the semver format exactly are the tags from upstream
-      run: echo tag=$(git tag -l v\* | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$" | sort -V | tail -n1) >> $GITHUB_OUTPUT
+      run: echo tag=$(git tag -l v\* | grep -E "^v${{ inputs.major_version }}\.[0-9]+\.[0-9]+$" | sort -V | tail -n1) >> $GITHUB_OUTPUT
     - name: Get dd tag
       id: get_dd_tag
       shell: bash


### PR DESCRIPTION
Allows to pin the major version

<!--
Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.

This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
-->

### Description

Please explain the changes you made here and their impact.

### Checklist

- [ ] I have checked the code and ensure it adheres to the project's coding standards.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added any necessary documentation (if appropriate).
