### PR TITLE
Add minor version input

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
 
-This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
+This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024 Datadog, Inc.
 -->
 
 ### Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,7 @@
 <!--
 Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.
 
-This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
+This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024 Datadog, Inc.
 -->
 
 ### Description

--- a/action.yml
+++ b/action.yml
@@ -34,6 +34,10 @@ inputs:
     description: Major version regex
     required: false
     default: "[0-9]+"
+  minor_version:
+    description: Minor version regex
+    required: false
+    default: "[0-9]+"
 
 runs:
   using: "composite"
@@ -67,7 +71,7 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       # We consider that the tags following the semver format exactly are the tags from upstream
-      run: echo tag=$(git tag -l v\* | grep -E "^v${{ inputs.major_version }}\.[0-9]+\.[0-9]+$" | sort -V | tail -n1) >> $GITHUB_OUTPUT
+      run: echo tag=$(git tag -l v\* | grep -E "^v${{ inputs.major_version }}\.${{ inputs.minor_version }}\.[0-9]+$" | sort -V | tail -n1) >> $GITHUB_OUTPUT
     - name: Get dd tag
       id: get_dd_tag
       shell: bash


### PR DESCRIPTION
<!--
Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.

This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2023 Datadog, Inc.
-->

### Description

As part of onboarding https://github.com/DataDog/etcd to `sync-upstream-release-tag`, we also want to pin the minor version in order to only sync etcd 3.5 and not 3.4 nor 3.6

Also bump the copyright year since we are changing things now

### Checklist

- [x] I have checked the code and ensure it adheres to the project's coding standards.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added any necessary documentation (if appropriate).
