### PR TITLE
Handle the case where the version tag doesn't contain the `v` prefix

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -71,7 +71,8 @@ runs:
       env:
         GITHUB_TOKEN: ${{ inputs.github_token }}
       # We consider that the tags following the semver format exactly are the tags from upstream
-      run: echo tag=$(git tag -l v\* | grep -E "^v${{ inputs.major_version }}\.${{ inputs.minor_version }}\.[0-9]+$" | sort -V | tail -n1) >> $GITHUB_OUTPUT
+      # Tag can contain a v prefix or not so we need to handle both cases
+      run: echo tag=$(git tag -l | grep -E "^(v)?${{ inputs.major_version }}\.${{ inputs.minor_version }}\.[0-9]+$" | sort -V | tail -n1) >> $GITHUB_OUTPUT
     - name: Get dd tag
       id: get_dd_tag
       shell: bash


### PR DESCRIPTION
<!--
Unless explicitly stated otherwise all files in this repository are licensed under the Apache License 2.0.

This product includes software developed at Datadog (https://www.datadoghq.com/). Copyright 2024 Datadog, Inc.
-->

### Description

The `kata-containers/kata-containers` repository is using X.Y.Z versioning scheme, which is not handled properly by the action. 

### Checklist

- [ ] I have checked the code and ensure it adheres to the project's coding standards.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have added any necessary documentation (if appropriate).
